### PR TITLE
restore python version numbers per h-vetinari 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   skip: True  # [py<39]
   entry_points:
     - labbench = labbench.cli.__main__:do_cli
-  number: 0
+  number: 1
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.8
     - pip
     - hatchling
     - typing-extensions
     - future
   run:
-    - python
+    - python >=3.8
     - psutil >=5.0
     - validators >=0.20.0
     - pip


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
